### PR TITLE
Some left-over changes on the about page.

### DIFF
--- a/static/pages/about/about.html
+++ b/static/pages/about/about.html
@@ -72,7 +72,7 @@
             As seen in
           </h1>
         </md-card-title>
-        <md-card-actions layout-gt-sm="row" layout="column" layout-align="space-between" layout-fill>
+        <md-card-actions layout-gt-sm="row" layout="column" layout-align="space-between center" layout-fill>
           <md-button aria-label="TechCrunch Press"
                      class="md-no-ink about-page-press-logo-button"
                      href="https://techcrunch.com/2014/02/26/meet-oppia-googles-new-open-source-project-that-lets-anyone-create-an-interactive-learning-experience/"
@@ -144,7 +144,7 @@
   .about-page-press-box {
     width: 850px;
   }
-  @media only screen and (max-width : 1000px) {
+  @media only screen and (max-width : 959px) {
     .about-page-reference-logo {
       -webkit-filter: grayscale(0);
       filter: grayscale(0);
@@ -156,7 +156,7 @@
       width: auto;
     }
   }
-  @media only screen and (min-width : 1000px) {
+  @media only screen and (min-width : 959px) {
     .techcrunch-logo {
       height: 32px;
       margin-top: 6px;
@@ -171,7 +171,6 @@
     }
     .edx-logo {
       height: 30px;
-      margin-top: -6px;
     }
   }
 </style>


### PR DESCRIPTION
Was doing some last minute QA work and figured these changes would make things seem smoother.

- [x] Make image breakpoint more exact, to match the switch between desktop/mobile view.
- [x] Prevent button from stretching entire screen, this was because of material design child alignment feature.