### PR TITLE
Use constants.js to sync up backend and frontend constants.

### DIFF
--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -34,6 +34,7 @@ CURR_DIR = os.path.abspath(os.getcwd())
 OPPIA_TOOLS_DIR = os.path.join(CURR_DIR, '..', 'oppia_tools')
 
 DIRS_TO_ADD_TO_SYS_PATH = [
+    CURR_DIR,
     os.path.join(
         OPPIA_TOOLS_DIR, 'google_appengine_1.9.73', 'google_appengine'),
     os.path.join(OPPIA_TOOLS_DIR, 'webtest-1.4.2'),

--- a/core/utility/constants.py
+++ b/core/utility/constants.py
@@ -24,12 +24,12 @@ CONSTANTS_JS_FILEPATH = os.path.join('static', 'assets', 'constants.js')
 
 def parse_json_from_js(js_file):
     """Extracts JSON object from JS file.
+
     Args:
-        js_file: file. A stream handling object of constants.js.
+        js_file: file. A stream representing the constants.js file.
 
     Returns:
-        dict(str, str). The dictionary containing variable name as key and
-            unicode string of variable value as value.
+        dict(str, str). A dict mapping constant names to their values.
     """
     text = js_file.read()
     first_bracket_index = text.find('= {')

--- a/core/utility/constants.py
+++ b/core/utility/constants.py
@@ -1,0 +1,40 @@
+# coding: utf-8
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Loads constants for backend use."""
+
+import json
+import os
+
+
+CONSTANTS_JS_FILEPATH = os.path.join('static', 'assets', 'constants.js')
+
+def parse_json_from_js(js_file):
+    """Extracts JSON object from JS file."""
+    text = js_file.read()
+    first_bracket_index = text.find('= {')
+    last_bracket_index = text.rfind('}')
+    json_text = text[first_bracket_index + 2:last_bracket_index + 1]
+    return json.loads(json_text)
+
+
+class Constants(dict):
+    """Transforms dict to object, attributes can be accesed by dot notation."""
+    __getattr__ = dict.__getitem__
+
+
+with open(CONSTANTS_JS_FILEPATH, 'r') as f:
+    constants = Constants(parse_json_from_js(f)) #pylint: disable=invalid-name

--- a/core/utility/constants.py
+++ b/core/utility/constants.py
@@ -25,11 +25,11 @@ CONSTANTS_JS_FILEPATH = os.path.join('static', 'assets', 'constants.js')
 def parse_json_from_js(js_file):
     """Extracts JSON object from JS file.
     Args:
-        js_file: str. The filestream object of constants.js.
+        js_file: file. A stream handling object of constants.js.
 
     Returns:
         dict(str, str). The dictionary containing variable name as key and
-            variable value as value.
+            unicode string of variable value as value.
     """
     text = js_file.read()
     first_bracket_index = text.find('= {')

--- a/core/utility/constants.py
+++ b/core/utility/constants.py
@@ -23,7 +23,14 @@ import os
 CONSTANTS_JS_FILEPATH = os.path.join('static', 'assets', 'constants.js')
 
 def parse_json_from_js(js_file):
-    """Extracts JSON object from JS file."""
+    """Extracts JSON object from JS file.
+    Args:
+        js_file: str. The filestream object of constants.js.
+
+    Returns:
+        dict(str, str). The dictionary containing variable name as key and
+            variable value as value.
+    """
     text = js_file.read()
     first_bracket_index = text.find('= {')
     last_bracket_index = text.rfind('}')
@@ -32,9 +39,9 @@ def parse_json_from_js(js_file):
 
 
 class Constants(dict):
-    """Transforms dict to object, attributes can be accesed by dot notation."""
+    """Transforms dict to object, attributes can be accessed by dot notation."""
     __getattr__ = dict.__getitem__
 
 
 with open(CONSTANTS_JS_FILEPATH, 'r') as f:
-    constants = Constants(parse_json_from_js(f)) #pylint: disable=invalid-name
+    CONSTANTS = Constants(parse_json_from_js(f))

--- a/core/utility/constants_test.py
+++ b/core/utility/constants_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for Constants object and cosntants.json file."""
+"""Tests for CONSTANTS object and cosntants.json file."""
 
 import os
 

--- a/core/utility/constants_test.py
+++ b/core/utility/constants_test.py
@@ -43,7 +43,7 @@ class ConstantsTest(app_engine_test_base.AppEngineTestBase):
         """
         # Ignore non-ASCII character in ADMIN_EMAIL_ADDRESS.
         encoded_admin_email_address = (
-            constants.constants.ADMIN_EMAIL_ADDRESS.encode(
+            constants.CONSTANTS.ADMIN_EMAIL_ADDRESS.encode(
                 'ascii', 'ignore'))
         self.assertEqual(
             config.ADMIN_EMAIL_ADDRESS, encoded_admin_email_address)

--- a/core/utility/constants_test.py
+++ b/core/utility/constants_test.py
@@ -1,0 +1,49 @@
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Constants object and cosntants.json file."""
+
+import os
+
+from core.tests import app_engine_test_base
+from core.utility import constants
+
+import config
+
+
+class ConstantsTest(app_engine_test_base.AppEngineTestBase):
+    """Tests for reading constants.js and converting its content to JSON format.
+    """
+
+    def test_constants_js_file_exists(self):
+        """Ensure that constants.js exists at the specified path."""
+        self.assertTrue(os.path.isfile(constants.CONSTANTS_JS_FILEPATH))
+
+    def test_constants_file_contains_test_json_value(self):
+        """Ensure constants.js has the specified TESTING_CONSTANT entry."""
+        with open(constants.CONSTANTS_JS_FILEPATH, 'r') as f:
+            json = constants.parse_json_from_js(f)
+            self.assertTrue(isinstance(json, dict))
+            self.assertEqual(json['TESTING_CONSTANT'], 'test')
+
+    def test_constants_and_config_are_consistent(self):
+        """Ensure that constants with the same name in both config.py and
+        constants.js are the same.
+        """
+        # Ignore non-ASCII character in ADMIN_EMAIL_ADDRESS.
+        encoded_admin_email_address = (
+            constants.constants.ADMIN_EMAIL_ADDRESS.encode(
+                'ascii', 'ignore'))
+        self.assertEqual(
+            config.ADMIN_EMAIL_ADDRESS, encoded_admin_email_address)

--- a/static/app.js
+++ b/static/app.js
@@ -16,6 +16,10 @@ var oppiaFoundationWebsite = angular.module(
   'oppiaFoundationWebsite', ['ngMaterial', 'ngMessages', 'ngRoute', 'duScroll',
     'ui.bootstrap']);
 
+for (var constantName in constants) {
+  oppiaFoundationWebsite.constant(constantName, constants[constantName]);
+}
+
 oppiaFoundationWebsite.config(['$routeProvider', function($routeProvider) {
   $routeProvider
     .when('/', {
@@ -61,8 +65,6 @@ oppiaFoundationWebsite.run([
     };
   }
 ]);
-
-oppiaFoundationWebsite.constant('ADMIN_EMAIL_ADDRESS', 'admin@example.com');
 
 oppiaFoundationWebsite.constant('MAILHANDLER_URL', '/ajax/mailhandler');
 

--- a/static/assets/constants.js
+++ b/static/assets/constants.js
@@ -1,0 +1,15 @@
+/* eslint quotes: ["error", "double", "avoid-escape"] */
+/* eslint quote-props: [2, "always"]*/
+/* Don't modify anything outside the {} brackets.
+ * Insides of the {} brackets should be formatted as a JSON object.
+ * JSON rules:
+ * 1. All keys and string values must be enclosed in double quotes.
+ * 2. Each key/value pair should be on a new line.
+ * 3. All values and keys must be constant, you can't use any Javascript
+ *    functions.
+ * 4. Do not use final comma.
+ */
+var constants = {
+  "TESTING_CONSTANT": "test",
+  "ADMIN_EMAIL_ADDRESS": "admin_email@domain.com"
+};

--- a/static/index.html
+++ b/static/index.html
@@ -28,6 +28,7 @@
     <!-- Smooth scroll library -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-scroll/1.0.2/angular-scroll.min.js"></script>
 
+    <script src="/assets/constants.js"></script>
     <script src="app.js"></script>
     <script src="pages/navbar/NavigationBarDirective.js"></script>
     <script src="pages/volunteer/VolunteerInfoDefinitions.js"></script>

--- a/static/pages/partnerships/Partnerships.js
+++ b/static/pages/partnerships/Partnerships.js
@@ -20,7 +20,7 @@ oppiaFoundationWebsite.controller(
         $scope, $http, $mdDialog, $log,
         ADMIN_EMAIL_ADDRESS, MAILHANDLER_URL, THANKYOU_MESSAGE) {
       $scope.ADMIN_EMAIL = ADMIN_EMAIL_ADDRESS;
-      $scope.PARTNERSHIPS_EMAIL_SUBJECT = 'Partnering%20with%20Oppia'
+      $scope.PARTNERSHIPS_EMAIL_SUBJECT = 'Partnering%20with%20Oppia';
       $scope.submitContactUsForm = function(
           fullName, email, organization, comment, evt) {
         $http.post(MAILHANDLER_URL, {

--- a/static/pages/partnerships/partnerships.html
+++ b/static/pages/partnerships/partnerships.html
@@ -506,7 +506,7 @@
     margin: auto;
     max-width: 850px;
   }
-  .partnerships-page-donate-hand-image{
+  .partnerships-page-donate-hand-image {
     border: 0;
     display: block;
     float: right;
@@ -514,12 +514,12 @@
     position: relative;
   }
   @media screen and (max-width: 1279px) {
-    .partnerships-page-donate-hand-image{
+    .partnerships-page-donate-hand-image {
       top: 30px;
     }
   }
   @media screen and (min-width: 100px) and (max-width: 500px) {
-    .partnerships-page-donate-hand-image{
+    .partnerships-page-donate-hand-image {
       width: 250px;
     }
   }


### PR DESCRIPTION
This PR adds constants.js, the necessary backend infrastructure to read its contents and the backend tests.
PTAL @seanlip.