### PR TITLE
Use sidenav instead of md-menu for collapsed navbar

### DIFF
--- a/static/assets/css/stylesheet.css
+++ b/static/assets/css/stylesheet.css
@@ -564,6 +564,11 @@ Full-Width Styles
   transform: scale(1);
 }
 
+md-sidenav {
+  min-width: 0;
+  max-width: 300px;
+}
+
 .oppia-foundation-quote-box {
   -webkit-box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
   box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);

--- a/static/assets/css/stylesheet.css
+++ b/static/assets/css/stylesheet.css
@@ -567,6 +567,7 @@ Full-Width Styles
 md-sidenav {
   min-width: 0;
   max-width: 300px;
+  width: auto;
 }
 
 .oppia-foundation-quote-box {

--- a/static/assets/icons/baseline-close-24px.svg
+++ b/static/assets/icons/baseline-close-24px.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/static/index.html
+++ b/static/index.html
@@ -44,9 +44,9 @@
   <body layout="row" aria-label="Oppia Foundation Page">
     <div class="outer">
       <md-sidenav class="md-sidenav-right
-                                           md-whiteframe-4dp
-                                           oppia-foundation-green-background"
-        md-component-id="right">
+                         md-whiteframe-4dp
+                         oppia-foundation-green-background"
+                  md-component-id="right">
         <side-bar></side-bar>
       </md-sidenav>
       <header role="banner">

--- a/static/index.html
+++ b/static/index.html
@@ -31,6 +31,7 @@
     <script src="/assets/constants.js"></script>
     <script src="app.js"></script>
     <script src="pages/navbar/NavigationBarDirective.js"></script>
+    <script src="pages/navbar/SideBarDirective.js"></script>
     <script src="pages/volunteer/VolunteerInfoDefinitions.js"></script>
     <script src="pages/volunteer/Volunteer.js"></script>
     <script src="pages/volunteer/VolunteerProfilesService.js"></script>
@@ -41,6 +42,12 @@
   </head>
 
   <body layout="row" aria-label="Oppia Foundation Page">
+    <md-sidenav class="md-sidenav-right
+                       md-whiteframe-4dp
+                       oppia-foundation-green-background"
+                md-component-id="right">
+      <side-bar></side-bar>
+    </md-sidenav>
     <div class="outer">
       <header role="banner">
         <navigation-bar></navigation-bar>
@@ -51,10 +58,10 @@
             <div ng-view layout-fill autoscroll="true" flex="noshrink"></div>
           </div>
         </section>
+        <footer>
+          <bottom-navigation></bottom-navigation>
+        </footer>
       </main>
-      <footer>
-        <bottom-navigation></bottom-navigation>
-      </footer>
     </div>
   </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -42,13 +42,13 @@
   </head>
 
   <body layout="row" aria-label="Oppia Foundation Page">
-    <md-sidenav class="md-sidenav-right
-                       md-whiteframe-4dp
-                       oppia-foundation-green-background"
-                md-component-id="right">
-      <side-bar></side-bar>
-    </md-sidenav>
     <div class="outer">
+      <md-sidenav class="md-sidenav-right
+                                           md-whiteframe-4dp
+                                           oppia-foundation-green-background"
+        md-component-id="right">
+        <side-bar></side-bar>
+      </md-sidenav>
       <header role="banner">
         <navigation-bar></navigation-bar>
       </header>

--- a/static/pages/navbar/NavigationBarDirective.js
+++ b/static/pages/navbar/NavigationBarDirective.js
@@ -18,7 +18,7 @@ oppiaFoundationWebsite.directive('navigationBar', [function() {
     scope: {},
     templateUrl: '/pages/navbar/navbar.html',
     controller: ['$scope', '$mdSidenav', function($scope, $mdSidenav) {
-      $scope.open = function() {
+      $scope.openSideBar = function() {
         $mdSidenav('right').open();
       };
     }]

--- a/static/pages/navbar/SideBarDirective.js
+++ b/static/pages/navbar/SideBarDirective.js
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-oppiaFoundationWebsite.directive('navigationBar', [function() {
+oppiaFoundationWebsite.directive('sideBar', [function() {
   return {
     restrict: 'E',
     scope: {},
-    templateUrl: '/pages/navbar/navbar.html',
+    templateUrl: '/pages/navbar/sidebar.html',
     controller: ['$scope', '$mdSidenav', function($scope, $mdSidenav) {
-      $scope.open = function() {
-        $mdSidenav('right').open();
+      $scope.close = function() {
+        $mdSidenav('right').close();
       };
     }]
   };

--- a/static/pages/navbar/SideBarDirective.js
+++ b/static/pages/navbar/SideBarDirective.js
@@ -18,7 +18,7 @@ oppiaFoundationWebsite.directive('sideBar', [function() {
     scope: {},
     templateUrl: '/pages/navbar/sidebar.html',
     controller: ['$scope', '$mdSidenav', function($scope, $mdSidenav) {
-      $scope.close = function() {
+      $scope.closeSideBar = function() {
         $mdSidenav('right').close();
       };
     }]

--- a/static/pages/navbar/navbar.html
+++ b/static/pages/navbar/navbar.html
@@ -19,7 +19,7 @@
   <md-button aria-label="Open links menu"
              class="side-bar-menu-button"
              hide-gt-sm
-             ng-click="open()">
+             ng-click="openSideBar()">
     <md-icon class="navbar-oppia-foundation-icon"
              md-svg-src="/assets/icons/sharp-view_headline-24px.svg"
              aria-label="Sidebar button">

--- a/static/pages/navbar/navbar.html
+++ b/static/pages/navbar/navbar.html
@@ -16,42 +16,15 @@
   <md-nav-item md-nav-href="#!about" hide-xs hide-sm>About</md-nav-item>
   <md-nav-item md-nav-href="#!partnerships" hide-xs hide-sm>Partnerships</md-nav-item>
   <md-nav-item md-nav-href="#!volunteer" hide-xs hide-sm>Volunteer</md-nav-item>
-  <md-menu md-position-mode="target-left target" hide-gt-sm>
-    <md-button aria-label="Open links menu"
-               class="side-bar-menu-button"
-               ng-click="$mdMenu.open()">
-      <md-icon class="navbar-oppia-foundation-icon"
-               md-svg-src="/assets/icons/sharp-view_headline-24px.svg"
-               aria-label="Links Menu">
-      </md-icon>
-    </md-button>
-    <md-menu-content width="2">
-      <md-menu-item>
-        <md-button ng-href="#!about">
-          <md-icon md-svg-src="/assets/icons/round-info-24px.svg" style="color:white;"></md-icon>
-          <span class="oppia-foundation-uppercase-text oppia-foundation-white-text">About</span>
-        </md-button>
-      </md-menu-item>
-      <md-menu-item>
-        <md-button ng-href="#!partnerships">
-          <md-icon md-svg-src="/assets/icons/round-business_center-24px.svg" style="color:white;"></md-icon>
-          <span class="oppia-foundation-uppercase-text oppia-foundation-white-text">Partnerships</span>
-        </md-button>
-      </md-menu-item>
-      <md-menu-item>
-        <md-button ng-href="#!volunteer">
-          <md-icon md-svg-src="/assets/icons/round-people_outline-24px.svg" style="color:white;"></md-icon>
-          <span class="oppia-foundation-uppercase-text oppia-foundation-white-text">Volunteer</span>
-        </md-button>
-      </md-menu-item>
-      <md-menu-item>
-        <md-button ng-href="#!donate">
-          <md-icon md-svg-src="/assets/icons/cards-heart.svg" style="color:white;"></md-icon>
-          <span class="oppia-foundation-uppercase-text oppia-foundation-white-text">Donate</span>
-        </md-button>
-      </md-menu-item>
-    </md-menu-content>
-  </md-menu>
+  <md-button aria-label="Open links menu"
+             class="side-bar-menu-button"
+             hide-gt-sm
+             ng-click="open()">
+    <md-icon class="navbar-oppia-foundation-icon"
+             md-svg-src="/assets/icons/sharp-view_headline-24px.svg"
+             aria-label="Sidebar button">
+    </md-icon>
+  </md-button>
   <md-nav-item hide-xs hide-sm md-nav-href="#!donate">Donate</md-nav-item>
 </md-nav-bar>
 

--- a/static/pages/navbar/sidebar.html
+++ b/static/pages/navbar/sidebar.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<md-toolbar layout="row" style="padding-top: 10px;">
+    <img src="/assets/images/navbar/oppia_foundation_logo.png"
+         class="side-nav-oppia-foundation-icon"
+         layout="row"
+         aria-label="Oppia Foundation Logo"
+         alt="Oppia Foundation logo">
+    <md-button md-no-ink
+               ng-click="close()"
+               class="toggle-side-nav-button">
+      <md-icon md-svg-src="/assets/icons/baseline-close-24px.svg"
+               aria-label="Close sidebar icon">
+      </md-icon>
+    </md-button>
+</md-toolbar>
+<md-list layout="column">
+  <md-divider></md-divider>
+  <md-list-item ng-href="#!about" ng-click="close()">
+    <div class="md-list-item-text" layout="row" layout-align="start" flex>
+      <md-icon class="side-bar-icon"
+               md-svg-src="/assets/icons/round-info-24px.svg"
+               aria-label="About icon">
+      </md-icon>
+      <h6 class="oppia-foundation-uppercase-text
+                 oppia-foundation-white-text">
+        About
+      </h6>
+    </div>
+    <md-divider></md-divider>
+  </md-list-item>
+  <md-list-item ng-href="#!partnerships" ng-click="close()">
+    <div class="md-list-item-text" layout="row" layout-align="start" flex>
+      <md-icon class="side-bar-icon"
+               md-svg-src="/assets/icons/round-business_center-24px.svg"
+               aria-label="Partnerships icon">
+      </md-icon>
+      <h6 class="oppia-foundation-uppercase-text
+                       oppia-foundation-white-text">
+        Partnerships
+      </h6>
+    </div>
+    <md-divider></md-divider>
+  </md-list-item>
+  <md-list-item ng-href="#!volunteer" ng-click="close()">
+    <div class="md-list-item-text" layout="row" layout-align="start" flex>
+      <md-icon class="side-bar-icon"
+               md-svg-src="/assets/icons/round-people_outline-24px.svg"
+               aria-label="Volunteer icon">
+      </md-icon>
+      <h6 class="oppia-foundation-uppercase-text
+                       oppia-foundation-white-text">
+        Volunteer
+      </h6>
+    </div>
+    <md-divider></md-divider>
+  </md-list-item>
+  <md-list-item ng-href="#!donate" ng-click="close()">
+    <div class="md-list-item-text" layout="row" layout-align="start" flex>
+      <md-icon class="side-bar-icon"
+               md-svg-src="/assets/icons/cards-heart.svg"></md-icon>
+      <h6 class="oppia-foundation-uppercase-text
+                       oppia-foundation-white-text">
+        Donate
+      </h6>
+    </div>
+    <md-divider></md-divider>
+  </md-list-item>
+</md-list>
+<style>
+  .side-bar-icon {
+    color:white;
+    margin: 0 10px 0 0;
+    height: 56px;
+  }
+  md-list-item.md-no-proxy {
+    padding: 16px;
+  }
+  .side-nav-oppia-foundation-icon {
+    border: 0;
+    display: block;
+    height: auto;
+    margin: 20px 0px 20px 20px;
+    width: 220px;
+  }
+  .md-button.toggle-side-nav-button {
+    height: 30px;
+    min-width: 24px;
+    margin: 12px 10px;
+  }
+</style>

--- a/static/pages/navbar/sidebar.html
+++ b/static/pages/navbar/sidebar.html
@@ -69,8 +69,8 @@
 <style>
   .side-bar-icon {
     color:white;
-    margin: 0 10px 0 0;
     height: 56px;
+    margin: 0 10px 0 0;
   }
   md-list-item.md-no-proxy {
     padding: 16px;
@@ -84,7 +84,7 @@
   }
   .md-button.toggle-side-nav-button {
     height: 30px;
-    min-width: 24px;
     margin: 12px 10px;
+    min-width: 24px;
   }
 </style>

--- a/static/pages/navbar/sidebar.html
+++ b/static/pages/navbar/sidebar.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <md-toolbar layout="row" style="padding-top: 10px;">
-    <img src="/assets/images/navbar/oppia_foundation_logo.png"
-         class="side-nav-oppia-foundation-icon"
-         layout="row"
-         aria-label="Oppia Foundation Logo"
-         alt="Oppia Foundation logo">
-    <md-button md-no-ink
-               ng-click="close()"
-               class="toggle-side-nav-button">
-      <md-icon md-svg-src="/assets/icons/baseline-close-24px.svg"
-               aria-label="Close sidebar icon">
-      </md-icon>
-    </md-button>
+  <img src="/assets/images/navbar/oppia_foundation_logo.png"
+       class="side-nav-oppia-foundation-icon"
+       layout="row"
+       aria-label="Oppia Foundation Logo"
+       alt="Oppia Foundation logo">
+  <md-button md-no-ink
+             ng-click="closeSideBar()"
+             class="toggle-side-nav-button">
+    <md-icon md-svg-src="/assets/icons/baseline-close-24px.svg"
+             aria-label="Close sidebar icon">
+    </md-icon>
+  </md-button>
 </md-toolbar>
 <md-list layout="column">
   <md-divider></md-divider>
-  <md-list-item ng-href="#!about" ng-click="close()">
+  <md-list-item ng-href="#!about" ng-click="closeSideBar()">
     <div class="md-list-item-text" layout="row" layout-align="start" flex>
       <md-icon class="side-bar-icon"
                md-svg-src="/assets/icons/round-info-24px.svg"
@@ -28,38 +28,39 @@
     </div>
     <md-divider></md-divider>
   </md-list-item>
-  <md-list-item ng-href="#!partnerships" ng-click="close()">
+  <md-list-item ng-href="#!partnerships" ng-click="closeSideBar()">
     <div class="md-list-item-text" layout="row" layout-align="start" flex>
       <md-icon class="side-bar-icon"
                md-svg-src="/assets/icons/round-business_center-24px.svg"
                aria-label="Partnerships icon">
       </md-icon>
       <h6 class="oppia-foundation-uppercase-text
-                       oppia-foundation-white-text">
+                 oppia-foundation-white-text">
         Partnerships
       </h6>
     </div>
     <md-divider></md-divider>
   </md-list-item>
-  <md-list-item ng-href="#!volunteer" ng-click="close()">
+  <md-list-item ng-href="#!volunteer" ng-click="closeSideBar()">
     <div class="md-list-item-text" layout="row" layout-align="start" flex>
       <md-icon class="side-bar-icon"
                md-svg-src="/assets/icons/round-people_outline-24px.svg"
                aria-label="Volunteer icon">
       </md-icon>
       <h6 class="oppia-foundation-uppercase-text
-                       oppia-foundation-white-text">
+                 oppia-foundation-white-text">
         Volunteer
       </h6>
     </div>
     <md-divider></md-divider>
   </md-list-item>
-  <md-list-item ng-href="#!donate" ng-click="close()">
+  <md-list-item ng-href="#!donate" ng-click="closeSideBar()">
     <div class="md-list-item-text" layout="row" layout-align="start" flex>
       <md-icon class="side-bar-icon"
-               md-svg-src="/assets/icons/cards-heart.svg"></md-icon>
+               md-svg-src="/assets/icons/cards-heart.svg">
+      </md-icon>
       <h6 class="oppia-foundation-uppercase-text
-                       oppia-foundation-white-text">
+                 oppia-foundation-white-text">
         Donate
       </h6>
     </div>


### PR DESCRIPTION
I decided to __not__ make the Oppia foundation logo in the sidenav a button. Might reverse my decision later though if people demands it to be a button.

GIF:
iPhone 
![2018-09-11 11 42 17](https://user-images.githubusercontent.com/11153258/45371168-edea5480-b5b7-11e8-9275-65d60396c755.gif)

Pixel2
![2018-09-11 11 46 40](https://user-images.githubusercontent.com/11153258/45371374-6bae6000-b5b8-11e8-90fd-76a3f95eb47e.gif)


![2018-09-11 02 58 45](https://user-images.githubusercontent.com/11153258/45367782-06ef0780-b5b0-11e8-9e6c-0a3a0b0bd0a4.gif)
