### PR TITLE
Fix #66: Cursor change to pointer when hover over video control buttons

### DIFF
--- a/.htmllintrc
+++ b/.htmllintrc
@@ -32,7 +32,7 @@
     "tag-self-close": false,
     "doctype-first": false,
     "doctype-html5": false,
-    "attr-name-style": "dash",
+    "attr-name-style": false,
     "attr-name-ignore-regex": false,
     "attr-no-dup": true,
     "attr-no-unsafe-char": false,

--- a/static/assets/css/stylesheet.css
+++ b/static/assets/css/stylesheet.css
@@ -90,6 +90,14 @@ video {
   vertical-align: baseline;
 }
 
+video::-webkit-media-controls-fullscreen-button,
+video::-webkit-media-controls-overlay-play-button,
+video::-webkit-media-controls-timeline,
+video::-webkit-media-controls-mute-button,
+video::-webkit-media-controls-toggle-closed-captions-button,
+video::-webkit-media-controls-volume-slider {
+  cursor: pointer;
+}
 
 /* HTML5 display-role reset for older browsers */
 

--- a/static/pages/home/home.html
+++ b/static/pages/home/home.html
@@ -83,7 +83,8 @@
       <div class="macbook">
         <div class="screen">
           <div class="viewport">
-            <video controls class="home-page-interactions-video">
+            <video controls controlsList="nodownload"
+                  class="home-page-interactions-video">
               <source src="/assets/videos/Interactions_video.mp4"
                       type="video/mp4">
               Your browser does not support the video tag.
@@ -129,7 +130,7 @@
         <div class="macbook">
           <div class="screen">
             <div class="viewport" controls>
-              <video controls
+              <video controls controlsList="nodownload"
                      class="home-page-interactions-video">
                 <source src="/assets/videos/Interactions_video.mp4"
                         type="video/mp4">


### PR DESCRIPTION
I disabled the download button. User can right click the video to download it.

Changes are live at https://oppia-foundation-test-server-1.appspot.com/