### PR TITLE
Mobile responsive navbar

### DIFF
--- a/static/assets/css/stylesheet.css
+++ b/static/assets/css/stylesheet.css
@@ -370,8 +370,23 @@ Full-Width Styles
     padding-top: 80px;
     padding-bottom: 80px;
   }
+  .oppia-foundation-mobile-and-tablet-top-padding {
+    padding-top: 80px;
+  }
+  .oppia-foundation-mobile-and-tablet-top-padding-60 {
+    padding-top: 60px;
+  }
+  .oppia-foundation-mobile-and-tablet-top-padding-40 {
+    padding-top: 40px;
+  }
   .oppia-foundation-mobile-and-tablet-bottom-padding {
     padding-bottom: 80px;
+  }
+  .oppia-foundation-mobile-and-tablet-bottom-padding-60 {
+    padding-bottom: 60px;
+  }
+  .oppia-foundation-mobile-and-tablet-bottom-padding-40 {
+    padding-bottom: 40px;
   }
   .oppia-foundation-tablet-and-desktop-right-padding {
     padding-right: 40px;
@@ -406,8 +421,14 @@ Full-Width Styles
   .oppia-foundation-mobile-and-small-tablet-top-padding-40 {
     padding-top: 40px;
   }
+  .oppia-foundation-mobile-and-small-tablet-top-padding-60 {
+    padding-top: 60px;
+  }
   .oppia-foundation-mobile-and-small-tablet-bottom-padding-40 {
     padding-bottom: 40px;
+  }
+  .oppia-foundation-mobile-and-small-tablet-bottom-padding-60 {
+    padding-bottom: 60px;
   }
   .oppia-foundation-mobile-and-small-tablet-bottom-padding {
     padding-bottom: 80px;
@@ -577,6 +598,127 @@ md-sidenav {
 .oppia-foundation-cite-text-box {
   text-align: right;
   margin-top: 20px;
+}
+
+.oppia-foundation-header {
+  position: fixed;
+  width: 100%;
+  z-index: 1;
+}
+
+.headroom {
+  will-change: transform;
+  transition: transform 200ms linear;
+  -webkit-transition: transform 200ms linear;
+  -moz-transition: transform 200ms linear;
+  -ms-transition: transform 200ms linear;
+  -o-transition: transform 200ms linear;
+}
+
+.animated {
+  -webkit-animation-duration: .5s;
+  -moz-animation-duration: .5s;
+  -o-animation-duration: .5s;
+  animation-duration: .5s;
+  -webkit-animation-fill-mode: both;
+  -moz-animation-fill-mode: both;
+  -o-animation-fill-mode: both;
+  animation-fill-mode: both;
+  will-change: transform,opacity
+}
+
+@-webkit-keyframes slideDown {
+  0% {
+    -webkit-transform: translateY(-100%)
+  }
+
+  100% {
+    -webkit-transform: translateY(0)
+  }
+}
+
+@-moz-keyframes slideDown {
+  0% {
+    -moz-transform: translateY(-100%)
+  }
+
+  100% {
+    -moz-transform: translateY(0)
+  }
+}
+
+@-o-keyframes slideDown {
+  0% {
+    -o-transform: translateY(-100%)
+  }
+
+  100% {
+    -o-transform: translateY(0)
+  }
+}
+
+@keyframes slideDown {
+  0% {
+    transform: translateY(-100%)
+  }
+
+  100% {
+    transform: translateY(0)
+  }
+}
+
+.animated.slideDown {
+  -webkit-animation-name: slideDown;
+  -moz-animation-name: slideDown;
+  -o-animation-name: slideDown;
+  animation-name: slideDown
+}
+
+@-webkit-keyframes slideUp {
+  0% {
+    -webkit-transform: translateY(0)
+  }
+
+  100% {
+    -webkit-transform: translateY(-100%)
+  }
+}
+
+@-moz-keyframes slideUp {
+  0% {
+    -moz-transform: translateY(0)
+  }
+
+  100% {
+    -moz-transform: translateY(-100%)
+  }
+}
+
+@-o-keyframes slideUp {
+  0% {
+    -o-transform: translateY(0)
+  }
+
+  100% {
+    -o-transform: translateY(-100%)
+  }
+}
+
+@keyframes slideUp {
+  0% {
+    transform: translateY(0)
+  }
+
+  100% {
+    transform: translateY(-100%)
+  }
+}
+
+.animated.slideUp {
+  -webkit-animation-name: slideUp;
+  -moz-animation-name: slideUp;
+  -o-animation-name: slideUp;
+  animation-name: slideUp
 }
 
 /* Responsive font size on large view width. */

--- a/static/pages/about/about.html
+++ b/static/pages/about/about.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <section id="about">
   <md-card layout-fill class="oppia-foundation-small-tablet-and-desktop-vertical-padding
-                              oppia-foundation-mobile-and-tablet-vertical-padding-40
+                              oppia-foundation-mobile-and-tablet-top-padding
+                              oppia-foundation-mobile-and-tablet-bottom-padding-40
                               oppia-foundation-green-background">
     <md-card-content layout="column"
                      layout-align="center center"

--- a/static/pages/app.js
+++ b/static/pages/app.js
@@ -14,7 +14,7 @@
 
 var oppiaFoundationWebsite = angular.module(
   'oppiaFoundationWebsite', ['ngMaterial', 'ngMessages', 'ngRoute', 'duScroll',
-    'ui.bootstrap']);
+    'ui.bootstrap', 'headroom']);
 
 for (var constantName in constants) {
   oppiaFoundationWebsite.constant(constantName, constants[constantName]);

--- a/static/pages/donate/donate.html
+++ b/static/pages/donate/donate.html
@@ -51,8 +51,8 @@
                      layout-fill
                      layout-align="center"
                      class="oppia-foundation-horizontal-padding
-                            oppia-foundation-mobile-and-small-tablet-top-padding-40
-                            oppia-foundation-mobile-and-small-tablet-bottom-padding
+                            oppia-foundation-mobile-and-small-tablet-top-padding-60
+                            oppia-foundation-mobile-and-small-tablet-bottom-padding-60
                             oppia-foundation-small-tablet-and-desktop-vertical-padding
                             oppia-foundation-white-background
                             oppia-foundation-dark-green-text

--- a/static/pages/home/home.html
+++ b/static/pages/home/home.html
@@ -8,7 +8,8 @@
                      layout-align="center none"
                      class="oppia-foundation-horizontal-padding
                             oppia-foundation-small-tablet-and-desktop-vertical-padding
-                            oppia-foundation-mobile-and-tablet-vertical-padding-20
+                            oppia-foundation-mobile-and-tablet-bottom-padding-20
+                            oppia-foundation-mobile-and-tablet-top-padding-40
                             oppia-foundation-white-background
                             oppia-foundation-dark-green-text
                             oppia-foundation-no-padding

--- a/static/pages/index.html
+++ b/static/pages/index.html
@@ -26,6 +26,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/2.5.0/ui-bootstrap-tpls.min.js"></script>
     <!-- Smooth scroll library -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-scroll/1.0.2/angular-scroll.min.js"></script>
+    <!-- Headroom JS dependency -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.9.4/headroom.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.9.4/angular.headroom.min.js"></script>
 
     <script src="/assets/constants.js"></script>
     <script src="pages/app.js"></script>
@@ -46,7 +49,12 @@
       <md-sidenav class="md-sidenav-right md-whiteframe-4dp oppia-foundation-green-background" md-component-id="right">
         <side-bar></side-bar>
       </md-sidenav>
-      <header role="banner">
+      <header class="oppia-foundation-header"
+              role="banner"
+              headroom tolerance="3" offset="80"
+              classes="{'initial':'animated',
+                        'pinned':'slideDown',
+                        'unpinned':'slideUp'}">
         <navigation-bar></navigation-bar>
       </header>
       <main>

--- a/static/pages/partnerships/partnerships.html
+++ b/static/pages/partnerships/partnerships.html
@@ -3,7 +3,8 @@
          ng-controller="PartnershipsPage">
   <md-card class="oppia-foundation-white-background
                   oppia-foundation-small-tablet-and-desktop-vertical-padding
-                  oppia-foundation-mobile-and-tablet-vertical-padding-20"
+                  oppia-foundation-mobile-and-tablet-top-padding-60
+                  oppia-foundation-mobile-and-tablet-bottom-padding-40"
            layout="column"
            layout-gt-md="row"
            layout-fill>

--- a/static/pages/volunteer/volunteer.html
+++ b/static/pages/volunteer/volunteer.html
@@ -2,7 +2,7 @@
 <section id="volunteer" ng-controller="VolunteerPage">
   <md-card class="oppia-foundation-white-background
                   oppia-foundation-small-tablet-and-desktop-vertical-padding
-                  oppia-foundation-mobile-and-tablet-vertical-padding-20
+                  oppia-foundation-mobile-and-tablet-top-padding-60
                   oppia-foundation-horizontal-padding"
            flex
            layout-gt-sm="row"


### PR DESCRIPTION
On mobile (<960px view-width), navbar will disappear (slide up) on scroll down and re-appear (slide down) on scroll down.

On desktop(>=960px view-width), navbar will stay fixated at the top of the page.

Changes are live at: https://oppia-foundation-test-server.appspot.com/

@kevinlee12 (maybe @seanlip if you are interested too :D)
Since this PR primarily  deals with viewing the page on  small view-width (<960px)
1. Can you help me check if the navbar is behaving as expected on your phone (Ik we basically have the same phone but still).

2. I also have made some changes to the hero section of the: home, about, partnerships, volunteer and donate pages. This is because of the navbar sliding up and down so the hero section paddings looks weird when left as-is.
Sooooo I just want to get some help looking out for weird padding on the hero section :D