### PR TITLE
Add cache control headers to all static resources.

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -10,10 +10,16 @@ handlers:
 - url: /assets
   static_dir: static/assets
   secure: always
+  expiration: 10m
+  http_headers:
+    Cache-Control: 'public, max-age=600'
 
 - url: /pages
   static_dir: static/pages
   secure: always
+  expiration: 10m
+  http_headers:
+    Cache-Control: 'public, max-age=600'
 
 - url: /.*
   static_files: static/pages/index.html


### PR DESCRIPTION
This brings app.yaml into parity with the main oppia repo.