### PR TITLE
Fix #87: Relocate /oppia_tools to within the Foundation repo and parallelize CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@
 # Variables
 
 var_1: &docker_image circleci/python:2.7.15-browsers
-var_2: &oppia_tools_cache_key oppia-tools-cache-{{ .Branch }}-{{ checksum "oppia-tools-dependency-list.txt" }}-0.1.0
+var_2: &oppia_tools_cache_key oppia-tools-cache-{{ .Branch }}-{{ checksum "/tmp/oppia-tools-dependency-list.txt" }}-0.1.0
 var_3: &oppia_node_modules_cache_key oppia-node-modules-cache-{{ .Branch }}-{{ checksum "package-lock.json" }}-0.1.0
 
 # Default settings for each job
@@ -55,6 +55,13 @@ jobs:
           name: Run linter
           command: |
             bash scripts/run_linter.sh
+
+      - run:
+          # Generate a text file containing all dirs name within /oppia_tools
+          name: Generate oppia_tools cache key
+          command: |
+            touch /tmp/oppia-tools-dependency-list.txt
+            ls ~/foundation-website/oppia_tools > /tmp/oppia-tools-dependency-list.txt
 
       - save_cache:
           key: *oppia_node_modules_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
           keys:
             - v1.0-oppia-node-modules-cache-{{ checksum "package-lock.json"}}
             - v1.0-oppia-node-modules-cache-
+            - v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}
             - v1.00-oppia-tools-cache
             - v1.0-oppia-pip-cache-{{ checksum "ci-linter-requirements.txt" }}
             - v1.0-oppia-pip-cache-
@@ -50,4 +51,4 @@ jobs:
       - save_cache:
           key: v1.0-oppia-pip-cache-{{ checksum "ci-linter-requirements.txt" }}
           paths:
-            - ~/.cache/pip
+            - ~/.local/share/virtualenvs/venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             bash scripts/run_linter.sh
 
       - save_cache:
-          key: v1.00-oppia-tools-cache
+          key: v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}
           paths:
             - ./oppia_tools/
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,8 @@ jobs:
       - restore_cache:
           keys:
             - v1.0-oppia-node-modules-cache-{{ checksum "package-lock.json"}}
-            - v1.0-oppia-node-modules-cache-
             - v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}
-            - v1.00-oppia-tools-cache
             - v1.0-oppia-pip-cache-{{ checksum "ci-linter-requirements.txt" }}
-            - v1.0-oppia-pip-cache-
-
       - run:
           name: install dependencies
           command: |
@@ -39,6 +35,12 @@ jobs:
           name: run linter
           command: |
             bash scripts/run_linter.sh
+
+      - run:
+          name: remove .pyc files
+          command: |
+            find oppia_tools -name "*.pyc" -print -delete
+            find third_party -name "*.pyc" -print -delete
 
       - save_cache:
           key: v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,12 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: oppia-tools-cache
+          keys:
+            - v1.0-oppia-node-modules-cache-{{ checksum "package-lock.json"}}
+            - v1.0-oppia-node-modules-cache-
+            - v1.00-oppia-tools-cache
+            - v1.0-oppia-pip-cache-{{ checksum "ci-linter-requirements.txt" }}
+            - v1.0-oppia-pip-cache-
 
       - run:
           name: install dependencies
@@ -35,7 +40,12 @@ jobs:
             bash scripts/run_linter.sh
 
       - save_cache:
-          key: oppia-tools-cache
+          key: v1.00-oppia-tools-cache
           paths:
-            - ../oppia_tools/
-            - ./node_modules/
+            - ./oppia_tools/
+          key: v1.0-oppia-node-modules-cache-{{ checksum "package-lock.json"}}
+          paths:
+            - ./node_modules
+          key: v1.0-oppia-pip-cache-{{ checksum "ci-linter-requirements.txt" }}
+          paths:
+            - ~/.cache/pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,6 @@
 # Variables
 
 var_1: &docker_image circleci/python:2.7.15-browsers
-var_2: &oppia_tools_cache_key oppia-tools-cache-{{ .Branch }}-{{ checksum "oppia-tools-dependency-list.txt" }}-0.1.0
-var_3: &oppia_node_modules_cache_key oppia-node-modules-cache-{{ .Branch }}-{{ checksum "package-lock.json" }}-0.1.0
 
 # Default settings for each job
 anchor_1: &job_defaults
@@ -26,10 +24,6 @@ jobs:
 
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-            - *oppia_tools_cache_key
 
       - run:
           name: Install dependencies
@@ -52,11 +46,6 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          keys:
-            - *oppia_node_modules_cache_key
-            - *oppia_tools_cache_key
-
       - run:
           name: Install dependencies
           command: |
@@ -67,15 +56,6 @@ jobs:
           name: Run linter
           command: |
             bash scripts/run_linter.sh
-
-      - save_cache:
-          key: *oppia_node_modules_cache_key
-          paths:
-            - ./node_modules
-      - save_cache:
-          key: *oppia_tools_cache_key
-          paths:
-            - ./oppia_tools/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,8 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            bash scripts/setup.sh || exit 1
-            bash scripts/setup_gae.sh || exit 1
+            source scripts/setup.sh || exit 1
+            source scripts/setup_gae.sh || exit 1
 
       - run:
           name: Run tests
@@ -45,8 +45,8 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            bash scripts/setup.sh || exit 1
-            bash scripts/setup_gae.sh || exit 1
+              source scripts/setup.sh || exit 1
+              source scripts/setup_gae.sh || exit 1
 
       - run:
           name: Run linter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,35 @@
-# Python CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-python/ for more details
-#
+# Configuration file for https://circleci.com/gh/oppia/foundation-website
+
+# Note: YAML anchors allow an object to be re-used, reducing duplication.
+# The ampersand declares an alias for an object, then later the `<<: *name`
+# syntax dereferences it.
+# See http://blog.daemonl.com/2016/02/yaml.html
+# To validate changes, use an online parser, eg.
+# http://yaml-online-parser.appspot.com/
+
+# Variables
+
+var_1: &docker_image circleci/python:2.7.15-browsers
+var_2: &oppia_tools_cache_key oppia-tools-cache-{{ .Branch }}-{{ checksum "oppia-tools-dependency-list.txt" }}-0.1.0
+var_3: &oppia_node_modules_cache_key oppia-node-modules-cache-{{ .Branch }}-{{ checksum "package-lock.json" }}-0.1.0
+
+# Default settings for each job
+anchor_1: &job_defaults
+  working_directory: ~/foundation-website
+  docker:
+    - image: *docker_image
+
 version: 2
 jobs:
   backend_tests:
-    docker:
-      # specify the version you desire here
-      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:2.7.15-browsers
-
-    working_directory: ~/foundation-website
+    <<: *job_defaults
 
     steps:
       - checkout
 
       - restore_cache:
           keys:
-            - v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}
+            - *oppia_tools_cache_key
 
       - run:
           name: Run tests
@@ -25,29 +37,19 @@ jobs:
             bash scripts/run_backend_tests.sh --generate_coverage_report
 
       - save_cache:
-          key: v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}
+          key: *oppia_tools_cache_key
           paths:
             - ./oppia_tools/
   linter:
-    docker:
-      # specify the version you desire here
-      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:2.7.15-browsers
-
-    working_directory: ~/foundation-website
+    <<: *job_defaults
 
     steps:
       - checkout
 
       - restore_cache:
           keys:
-            - v1.0-oppia-node-modules-cache-{{ checksum "package-lock.json"}}
-      - restore_cache:
-          keys:
-            - v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}
-      - restore_cache:
-          keys:
-            - v1.0-oppia-pip-cache-{{ checksum "ci-linter-requirements.txt" }}
+            - *oppia_node_modules_cache_key
+            - *oppia_tools_cache_key
 
       - run:
           name: Run linter
@@ -55,19 +57,14 @@ jobs:
             bash scripts/run_linter.sh
 
       - save_cache:
-          key: v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}
-          paths:
-            - ./oppia_tools/
-      - save_cache:
-          key: v1.0-oppia-node-modules-cache-{{ checksum "package-lock.json"}}
+          key: *oppia_node_modules_cache_key
           paths:
             - ./node_modules
       - save_cache:
-          key: v1.0-oppia-pip-cache-{{ checksum "ci-linter-requirements.txt" }}
+          key: *oppia_tools_cache_key
           paths:
-            - "~/.cache/pip"
-            - "/usr/local/lib/python2.7/site-packages"
-            - "/usr/local/lib/site-python"
+            - ./oppia_tools/
+
 workflows:
   version: 2
   circleci_tasks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,6 @@ jobs:
           command: |
             bash scripts/run_backend_tests.sh --generate_coverage_report
 
-      - save_cache:
-          key: *oppia_tools_cache_key
-          paths:
-            - ./oppia_tools/
   linter:
     <<: *job_defaults
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,11 @@ jobs:
           key: v1.00-oppia-tools-cache
           paths:
             - ./oppia_tools/
+      - save_cache:
           key: v1.0-oppia-node-modules-cache-{{ checksum "package-lock.json"}}
           paths:
             - ./node_modules
+      - save_cache:
           key: v1.0-oppia-pip-cache-{{ checksum "ci-linter-requirements.txt" }}
           paths:
             - ~/.cache/pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,31 @@
 #
 version: 2
 jobs:
-  build:
+  backend_tests:
+    docker:
+      # specify the version you desire here
+      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
+      - image: circleci/python:2.7.15-browsers
+
+    working_directory: ~/foundation-website
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}
+
+      - run:
+          name: Run tests
+          command: |
+            bash scripts/run_backend_tests.sh --generate_coverage_report
+
+      - save_cache:
+          key: v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}
+          paths:
+            - ./oppia_tools/
+  linter:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
@@ -26,11 +50,6 @@ jobs:
             - v1.0-oppia-pip-cache-{{ checksum "ci-linter-requirements.txt" }}
 
       - run:
-          name: Run tests
-          command: |
-            bash scripts/run_backend_tests.sh --generate_coverage_report
-
-      - run:
           name: Run linter
           command: |
             bash scripts/run_linter.sh
@@ -49,3 +68,9 @@ jobs:
             - "~/.cache/pip"
             - "/usr/local/lib/python2.7/site-packages"
             - "/usr/local/lib/site-python"
+workflows:
+  version: 2
+  circleci_tasks:
+    jobs:
+      - backend_tests
+      - linter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,26 +18,25 @@ jobs:
       - restore_cache:
           keys:
             - v1.0-oppia-node-modules-cache-{{ checksum "package-lock.json"}}
+      - restore_cache:
+          keys:
             - v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}
+      - restore_cache:
+          keys:
             - v1.0-oppia-pip-cache-{{ checksum "ci-linter-requirements.txt" }}
-      - run:
-          name: install dependencies
-          command: |
-            bash scripts/setup.sh
-            bash scripts/setup_gae.sh
 
       - run:
-          name: run tests
+          name: Run tests
           command: |
             bash scripts/run_backend_tests.sh --generate_coverage_report
 
       - run:
-          name: run linter
+          name: Run linter
           command: |
             bash scripts/run_linter.sh
 
       - run:
-          name: remove .pyc files
+          name: Remove .pyc files
           command: |
             find oppia_tools -name "*.pyc" -print -delete
             find third_party -name "*.pyc" -print -delete

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,6 @@ jobs:
           command: |
             bash scripts/run_linter.sh
 
-      - run:
-          name: Remove .pyc files
-          command: |
-            find oppia_tools -name "*.pyc" -print -delete
-            find third_party -name "*.pyc" -print -delete
-
       - save_cache:
           key: v1.0-oppia-tools-cache-{{ checksum "oppia-tools-dependency-list.txt" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,4 +51,6 @@ jobs:
       - save_cache:
           key: v1.0-oppia-pip-cache-{{ checksum "ci-linter-requirements.txt" }}
           paths:
-            - ~/.local/share/virtualenvs/venv
+            - "~/.cache/pip"
+            - "/usr/local/lib/python2.7/site-packages"
+            - "/usr/local/lib/site-python"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@
 # Variables
 
 var_1: &docker_image circleci/python:2.7.15-browsers
-var_2: &oppia_tools_cache_key oppia-tools-cache-{{ .Branch }}-{{ checksum "/tmp/oppia-tools-dependency-list.txt" }}-0.1.0
+var_2: &oppia_tools_cache_key oppia-tools-cache-{{ .Branch }}-{{ checksum "oppia-tools-dependency-list.txt" }}-0.1.0
 var_3: &oppia_node_modules_cache_key oppia-node-modules-cache-{{ .Branch }}-{{ checksum "package-lock.json" }}-0.1.0
 
 # Default settings for each job
@@ -30,6 +30,12 @@ jobs:
       - restore_cache:
           keys:
             - *oppia_tools_cache_key
+
+      - run:
+          name: Install dependencies
+          command: |
+            bash scripts/setup.sh || exit 1
+            bash scripts/setup_gae.sh || exit 1
 
       - run:
           name: Run tests
@@ -52,16 +58,15 @@ jobs:
             - *oppia_tools_cache_key
 
       - run:
+          name: Install dependencies
+          command: |
+            bash scripts/setup.sh || exit 1
+            bash scripts/setup_gae.sh || exit 1
+
+      - run:
           name: Run linter
           command: |
             bash scripts/run_linter.sh
-
-      - run:
-          # Generate a text file containing all dirs name within /oppia_tools
-          name: Generate oppia_tools cache key
-          command: |
-            touch /tmp/oppia-tools-dependency-list.txt
-            ls ~/foundation-website/oppia_tools > /tmp/oppia-tools-dependency-list.txt
 
       - save_cache:
           key: *oppia_node_modules_cache_key

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ third_party/*
 *.pyc
 .coverage
 node_modules/*
+oppia_tools/*

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,7 +4,7 @@
 
 [MASTER]
 
-init-hook='import sys; sys.path.append("../oppia_tools/google_appengine_1.9.73/google_appengine"); sys.path.append("../oppia_tools/testfixtures-6.3.0");'
+init-hook='import sys; sys.path.append("./oppia_tools/google_appengine_1.9.73/google_appengine"); sys.path.append("./oppia_tools/testfixtures-6.3.0");'
 
 # Checks for correct docstring style
 load-plugins=pylint.extensions.docstyle

--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,7 @@ init-hook='import sys; sys.path.append("../oppia_tools/google_appengine_1.9.73/g
 
 # Checks for correct docstring style
 load-plugins=pylint.extensions.docstyle
-ignore=.vscode
+ignore=.vscode,oppia_tools
 
 # Use multiple processes to speed up Pylint.
 jobs=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ after_success:
 cache:
   # Cache dependencies.
   directories:
-    - ../oppia_tools/
+    - oppia_tools/
     - node_modules/
     - third_party/
     - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,4 @@ cache:
 
 before_cache:
     - find third_party -name "*.pyc" -print -delete
+    - find oppia_tools -name "*.pyc" -print -delete

--- a/app/core/tests/gae_suite.py
+++ b/app/core/tests/gae_suite.py
@@ -32,7 +32,7 @@ import dev_appserver
 
 CURR_DIR = os.path.abspath(os.getcwd())
 CORE_DIR = os.path.join(CURR_DIR, 'app', '')
-OPPIA_TOOLS_DIR = os.path.join(CURR_DIR, '..', 'oppia_tools')
+OPPIA_TOOLS_DIR = os.path.join(CURR_DIR, 'oppia_tools')
 
 DIRS_TO_ADD_TO_SYS_PATH = [
     CORE_DIR,

--- a/oppia-tools-dependency-list.txt
+++ b/oppia-tools-dependency-list.txt
@@ -1,8 +1,0 @@
-google_appengine_1.9.73
-node-6.9.1
-pycodestyle-2.3.1
-pydocstyle-2.1.1
-pylint-1.9.3
-pylint-runner-0.5.4
-test-fixtures-6.3.0
-webtest-1.4.2

--- a/oppia-tools-dependency-list.txt
+++ b/oppia-tools-dependency-list.txt
@@ -1,0 +1,8 @@
+google_appengine_1.9.73
+node-6.9.1
+pycodestyle-2.3.1
+pydocstyle-2.1.1
+pylint-1.9.3
+pylint-runner-0.5.4
+test-fixtures-6.3.0
+webtest-1.4.2

--- a/scripts/run_linter.sh
+++ b/scripts/run_linter.sh
@@ -22,10 +22,6 @@ if [ "$TRAVIS" == 'true' ]; then
   pip install -r ci-linter-requirements.txt
 fi
 
-if [ "$CI" == 'true' ]; then
-  pip install -r ci-linter-requirements.txt --user
-fi
-
 set -e
 
 export DEFAULT_SKIP_INSTALLING_THIRD_PARTY_LIBS=false

--- a/scripts/run_linter.sh
+++ b/scripts/run_linter.sh
@@ -22,6 +22,10 @@ if [ "$TRAVIS" == 'true' ]; then
   pip install -r ci-linter-requirements.txt
 fi
 
+if [ "$CI" == 'true' ]; then
+  pip install -r ci-linter-requirements.txt --user
+fi
+
 set -e
 
 export DEFAULT_SKIP_INSTALLING_THIRD_PARTY_LIBS=false

--- a/scripts/run_linter.sh
+++ b/scripts/run_linter.sh
@@ -68,13 +68,13 @@ if [ ! -d "$TOOLS_DIR/pycodestyle-2.3.1" ]; then
 fi
 
 if [ "$TRAVIS" == 'true' ]; then
-  pycodestyle -v --exclude=./node_modules,.git,./.vscode,./.circleci || exit 1
+  pycodestyle -v --exclude=./node_modules,.git,./.vscode,./.circleci,./oppia_tools || exit 1
   pydocstyle -v || exit 1
   pylint_runner -v || exit 1
 else
   # These commands might not work cross-platform.
   $PYTHON_CMD $TOOLS_DIR/pydocstyle-2.1.1/src/pydocstyle/__main__.py -v || exit 1
-  $PYTHON_CMD $TOOLS_DIR/pycodestyle-2.3.1/pycodestyle.py -v --exclude=./node_modules,.git,./.vscode,./.circleci || exit 1
+  $PYTHON_CMD $TOOLS_DIR/pycodestyle-2.3.1/pycodestyle.py -v --exclude=./node_modules,.git,./.vscode,./.circleci,./oppia_tools || exit 1
   $PYTHON_CMD $TOOLS_DIR/pylint-runner-0.5.4/pylint_runner/main.py -v || exit 1
 fi
 

--- a/scripts/run_linter.sh
+++ b/scripts/run_linter.sh
@@ -20,6 +20,9 @@ source $(dirname $0)/setup.sh || exit 1
 source $(dirname $0)/setup_util.sh || exit 1
 if [ "$TRAVIS" == 'true' ]; then
   pip install -r ci-linter-requirements.txt
+  export TRAVIS_PYDOCSTYLE = pydocstyle
+  export TRAVIS_PYCODESTYLE = pycodestyle
+  export TRAVIS_PYLINT_RUNNER = pylint_runner
 fi
 
 if [ "$CI" == 'true' ]; then
@@ -67,14 +70,17 @@ if [ ! -d "$TOOLS_DIR/pycodestyle-2.3.1" ]; then
   rm pycodestyle-2.3.1.tar.gz
 fi
 
+export PYDOCSTYLE_MATCH_DIR_ARG="^(?!oppia_tools|\.vscode).*"
+export PYCODESTYLE_EXCLUDE_ARG=./node_modules,.git,./.vscode,./.circleci,./oppia_tools,./third_party
+
 if [ "$TRAVIS" == 'true' ]; then
-  pydocstyle --match-dir="^(?!oppia_tools|\.vscode).*" -v || exit 1
-  pycodestyle -v --exclude=./node_modules,.git,./.vscode,./.circleci,./oppia_tools,./third_party || exit 1
-  pylint_runner -v || exit 1
+  $PYTHON_CMD $TOOLS_DIR/pydocstyle-2.1.1/src/pydocstyle/__main__.py --match-dir=$PYDOCSTYLE_MATCH_DIR_ARG -v || exit 1
+  $TRAVIS_PYCODESTYLE -v --exclude=$PYCODESTYLE_EXCLUDE_ARG || exit 1
+  $TRAVIS_PYLINT_RUNNER -v || exit 1
 else
   # These commands might not work cross-platform.
-  $PYTHON_CMD $TOOLS_DIR/pydocstyle-2.1.1/src/pydocstyle/__main__.py --match-dir="^(?!oppia_tools|\.vscode).*" -v || exit 1
-  $PYTHON_CMD $TOOLS_DIR/pycodestyle-2.3.1/pycodestyle.py -v --exclude=./node_modules,.git,./.vscode,./.circleci,./oppia_tools,./third_party || exit 1
+  $PYTHON_CMD $TOOLS_DIR/pydocstyle-2.1.1/src/pydocstyle/__main__.py --match-dir=$PYDOCSTYLE_MATCH_DIR_ARG -v || exit 1
+  $PYTHON_CMD $TOOLS_DIR/pycodestyle-2.3.1/pycodestyle.py -v --exclude=$PYCODESTYLE_EXCLUDE_ARG || exit 1
   $PYTHON_CMD $TOOLS_DIR/pylint-runner-0.5.4/pylint_runner/main.py -v || exit 1
 fi
 

--- a/scripts/run_linter.sh
+++ b/scripts/run_linter.sh
@@ -16,8 +16,20 @@
 #
 #     bash scripts/run_linter.sh
 
+if [ -z "$BASH_VERSION" ]
+then
+  echo ""
+  echo "  Please run me using bash: "
+  echo ""
+  echo "     bash $0"
+  echo ""
+  return 1
+fi
+
+set -e
 source $(dirname $0)/setup.sh || exit 1
 source $(dirname $0)/setup_util.sh || exit 1
+
 if [ "$TRAVIS" == 'true' ]; then
   pip install -r ci-linter-requirements.txt
 fi
@@ -25,8 +37,6 @@ fi
 if [ "$CI" == 'true' ]; then
   pip install -r ci-linter-requirements.txt --user
 fi
-
-set -e
 
 export DEFAULT_SKIP_INSTALLING_THIRD_PARTY_LIBS=false
 maybeInstallDependencies "$@"

--- a/scripts/run_linter.sh
+++ b/scripts/run_linter.sh
@@ -34,8 +34,8 @@ if [ "$TRAVIS" == 'true' ]; then
   pip install -r ci-linter-requirements.txt
 fi
 
-if [ "$CI" == 'true' ]; then
-  pip install -r ci-linter-requirements.txt
+if [ "$CIRCLECI" == 'true' ]; then
+  pip install -r ci-linter-requirements.txt --user
 fi
 
 export DEFAULT_SKIP_INSTALLING_THIRD_PARTY_LIBS=false

--- a/scripts/run_linter.sh
+++ b/scripts/run_linter.sh
@@ -68,13 +68,13 @@ if [ ! -d "$TOOLS_DIR/pycodestyle-2.3.1" ]; then
 fi
 
 if [ "$TRAVIS" == 'true' ]; then
-  pycodestyle -v --exclude=./node_modules,.git,./.vscode,./.circleci,./oppia_tools || exit 1
-  pydocstyle -v || exit 1
+  pydocstyle --match-dir="^(?!oppia_tools|\.vscode).*" -v || exit 1
+  pycodestyle -v --exclude=./node_modules,.git,./.vscode,./.circleci,./oppia_tools,./third_party || exit 1
   pylint_runner -v || exit 1
 else
   # These commands might not work cross-platform.
-  $PYTHON_CMD $TOOLS_DIR/pydocstyle-2.1.1/src/pydocstyle/__main__.py -v || exit 1
-  $PYTHON_CMD $TOOLS_DIR/pycodestyle-2.3.1/pycodestyle.py -v --exclude=./node_modules,.git,./.vscode,./.circleci,./oppia_tools || exit 1
+  $PYTHON_CMD $TOOLS_DIR/pydocstyle-2.1.1/src/pydocstyle/__main__.py --match-dir="^(?!oppia_tools|\.vscode).*" -v || exit 1
+  $PYTHON_CMD $TOOLS_DIR/pycodestyle-2.3.1/pycodestyle.py -v --exclude=./node_modules,.git,./.vscode,./.circleci,./oppia_tools,./third_party || exit 1
   $PYTHON_CMD $TOOLS_DIR/pylint-runner-0.5.4/pylint_runner/main.py -v || exit 1
 fi
 

--- a/scripts/run_linter.sh
+++ b/scripts/run_linter.sh
@@ -35,7 +35,7 @@ if [ "$TRAVIS" == 'true' ]; then
 fi
 
 if [ "$CI" == 'true' ]; then
-  pip install -r ci-linter-requirements.txt --user
+  pip install -r ci-linter-requirements.txt
 fi
 
 export DEFAULT_SKIP_INSTALLING_THIRD_PARTY_LIBS=false

--- a/scripts/run_linter.sh
+++ b/scripts/run_linter.sh
@@ -74,9 +74,9 @@ export PYDOCSTYLE_MATCH_DIR_ARG="^(?!oppia_tools|\.vscode).*"
 export PYCODESTYLE_EXCLUDE_ARG=./node_modules,.git,./.vscode,./.circleci,./oppia_tools,./third_party
 
 if [ "$TRAVIS" == 'true' ]; then
-  export PYDOCSTYLE ="pydocstyle"
-  export PYCODESTYLE ="pycodestyle"
-  export PYLINT_RUNNER ="pylint_runner"
+  export PYDOCSTYLE="pydocstyle"
+  export PYCODESTYLE="pycodestyle"
+  export PYLINT_RUNNER="pylint_runner"
 else
   # These commands might not work cross-platform.
   export PYDOCSTYLE="python ./oppia_tools/pydocstyle-2.1.1/src/pydocstyle/__main__.py"

--- a/scripts/run_linter.sh
+++ b/scripts/run_linter.sh
@@ -20,9 +20,6 @@ source $(dirname $0)/setup.sh || exit 1
 source $(dirname $0)/setup_util.sh || exit 1
 if [ "$TRAVIS" == 'true' ]; then
   pip install -r ci-linter-requirements.txt
-  export TRAVIS_PYDOCSTYLE = pydocstyle
-  export TRAVIS_PYCODESTYLE = pycodestyle
-  export TRAVIS_PYLINT_RUNNER = pylint_runner
 fi
 
 if [ "$CI" == 'true' ]; then
@@ -70,19 +67,26 @@ if [ ! -d "$TOOLS_DIR/pycodestyle-2.3.1" ]; then
   rm pycodestyle-2.3.1.tar.gz
 fi
 
+# Pydocstyle's --match-dir: Only searches for dirs that match the regular expression pattern.
+# In this case, the regex excludes all dirs that begin with oppia_tools or .vscode.
 export PYDOCSTYLE_MATCH_DIR_ARG="^(?!oppia_tools|\.vscode).*"
+
 export PYCODESTYLE_EXCLUDE_ARG=./node_modules,.git,./.vscode,./.circleci,./oppia_tools,./third_party
 
 if [ "$TRAVIS" == 'true' ]; then
-  $PYTHON_CMD $TOOLS_DIR/pydocstyle-2.1.1/src/pydocstyle/__main__.py --match-dir=$PYDOCSTYLE_MATCH_DIR_ARG -v || exit 1
-  $TRAVIS_PYCODESTYLE -v --exclude=$PYCODESTYLE_EXCLUDE_ARG || exit 1
-  $TRAVIS_PYLINT_RUNNER -v || exit 1
+  export PYDOCSTYLE ="pydocstyle"
+  export PYCODESTYLE ="pycodestyle"
+  export PYLINT_RUNNER ="pylint_runner"
 else
   # These commands might not work cross-platform.
-  $PYTHON_CMD $TOOLS_DIR/pydocstyle-2.1.1/src/pydocstyle/__main__.py --match-dir=$PYDOCSTYLE_MATCH_DIR_ARG -v || exit 1
-  $PYTHON_CMD $TOOLS_DIR/pycodestyle-2.3.1/pycodestyle.py -v --exclude=$PYCODESTYLE_EXCLUDE_ARG || exit 1
-  $PYTHON_CMD $TOOLS_DIR/pylint-runner-0.5.4/pylint_runner/main.py -v || exit 1
+  export PYDOCSTYLE="python ./oppia_tools/pydocstyle-2.1.1/src/pydocstyle/__main__.py"
+  export PYCODESTYLE="python ./oppia_tools/pycodestyle-2.3.1/pycodestyle.py"
+  export PYLINT_RUNNER="python ./oppia_tools/pylint-runner-0.5.4/pylint_runner/main.py"
 fi
+
+$PYDOCSTYLE --match-dir=$PYDOCSTYLE_MATCH_DIR_ARG -v || exit 1
+$PYCODESTYLE -v --exclude=$PYCODESTYLE_EXCLUDE_ARG || exit 1
+$PYLINT_RUNNER -v || exit 1
 
 # Install third-party node modules for linting after checking for existing
 # installation.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -36,7 +36,7 @@ EXPECTED_PWD='foundation-website'
 # The second option allows this script to also be run from deployment folders.
 if [[ ${PWD##*/} != $EXPECTED_PWD ]]; then
   echo ""
-  echo "  WARNING   This script should be run from the foundation-website/root folder."
+  echo "  WARNING  This script should be run from the foundation-website/root folder."
   echo ""
   return 1
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -45,8 +45,7 @@ source scripts/setup_util.sh || exit 1
 
 export FOUNDATION_DIR=`pwd`
 export APP_DIR=$FOUNDATION_DIR/app
-export COMMON_DIR=$(cd $FOUNDATION_DIR/..; pwd)
-export TOOLS_DIR=$COMMON_DIR/oppia_tools
+export TOOLS_DIR=$FOUNDATION_DIR/oppia_tools
 export THIRD_PARTY_DIR=$FOUNDATION_DIR/third_party
 export NODE_MODULE_DIR=$FOUNDATION_DIR/node_modules
 

--- a/scripts/setup_gae.sh
+++ b/scripts/setup_gae.sh
@@ -21,6 +21,9 @@ if [ "$SETUP_GAE_DONE" ]; then
   return 0
 fi
 
+set -e
+source $(dirname $0)/setup.sh || exit 1
+
 export GOOGLE_APP_ENGINE_HOME=$TOOLS_DIR/google_appengine_1.9.73/google_appengine
 export COVERAGE_HOME=$TOOLS_DIR/coverage-4.5.1
 
@@ -46,3 +49,5 @@ if [ ! -d "$GOOGLE_APP_ENGINE_HOME" ]; then
   unzip -q gae-download.zip -d $TOOLS_DIR/google_appengine_1.9.73/
   rm gae-download.zip
 fi
+
+export SETUP_GAE_DONE=true

--- a/scripts/setup_gae.sh
+++ b/scripts/setup_gae.sh
@@ -21,9 +21,6 @@ if [ "$SETUP_GAE_DONE" ]; then
   return 0
 fi
 
-set -e
-source $(dirname $0)/setup.sh || exit 1
-
 export GOOGLE_APP_ENGINE_HOME=$TOOLS_DIR/google_appengine_1.9.73/google_appengine
 export COVERAGE_HOME=$TOOLS_DIR/coverage-4.5.1
 


### PR DESCRIPTION
- `oppia-tools-dependency-list.txt` is used to help with CircleCI cache validation for `/oppia_tools` directory

Fix #87 