### PR TITLE
Fix #117: Introduce workaround to prevent md-tab from shrinking md-tab-item to 0px

### DIFF
--- a/app/static/pages/home/home.html
+++ b/app/static/pages/home/home.html
@@ -774,6 +774,11 @@
   md-tabs-canvas {
     background: white;
   }
+  md-tab-item {
+    /* This is a workaround for md-tab sizing issue
+    https://github.com/angular/material/issues/4237 */
+    max-width: none !important;
+  }
   md-tabs-wrapper.md-stretch-tabs md-pagination-wrapper md-tab-item {
     font-family: "Capriola", "Roboto", Arial, sans-serif;
   }


### PR DESCRIPTION
Steps of reproducing issue:
Method 1: Reloading the page a bunch of times until bug presents itself.
Method 2: Sometimes the buggy tab will appear on first page load as well.
Screenshot of visual bug:
![Screen Shot 2019-07-12 at 10 23 33 AM](https://user-images.githubusercontent.com/11153258/61146576-3a7c1600-a48f-11e9-86a1-c2a65e62cb25.png)
This issue is a known issue from md-tab:
https://github.com/angular/material/issues/4237
I simply put in the workaround suggested by one of the commenter. Changes in this PR are live at:
https://oppia-foundation-test-server-1.appspot.com/