### PR TITLE
Update footer.html

### DIFF
--- a/app/static/pages/footer/footer.html
+++ b/app/static/pages/footer/footer.html
@@ -61,7 +61,7 @@
       <p><a href="https://www.oppia.org/terms">Terms of Service</a></p>
     </md-content>
     <md-content class="footer-background-color oppia-foundation-horizontal-padding oppia-foundation-white-text">
-      <p><a href="https://www.oppia.org/privacy">Privacy Policy</a></p>
+      <p><a href="https://www.oppia.org/privacy-policy">Privacy Policy</a></p>
     </md-content>
   </md-card-content>
 </md-card>


### PR DESCRIPTION
privacy policy link changed from "https://www.oppia.org/privacy" to "https://www.oppia.org/privacy-policy".